### PR TITLE
Fix parameters not took in account correctly and add method to match a getter correctly.

### DIFF
--- a/labai-jsr305-jaxb-plugin/src/main/java/com/sun/tools/xjc/addon/labai/JaxbNonnullPlugin.java
+++ b/labai-jsr305-jaxb-plugin/src/main/java/com/sun/tools/xjc/addon/labai/JaxbNonnullPlugin.java
@@ -1,11 +1,6 @@
 package com.sun.tools.xjc.addon.labai;
 
-import com.sun.codemodel.JAnnotationUse;
-import com.sun.codemodel.JClass;
-import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JMethod;
-import com.sun.codemodel.JPackage;
-import com.sun.codemodel.JTypeVar;
+import com.sun.codemodel.*;
 import com.sun.tools.xjc.BadCommandLineException;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.Plugin;
@@ -80,7 +75,7 @@ public class JaxbNonnullPlugin extends Plugin {
         if (v != null) {
             consumed++;
         }
-        if (v == null && generatePackageDefault) {
+        if (v == null && generatePackageDefault && packageDefaultClass == null) {
             v = DEFAULT_NULLABLE_ANNOTATION;
         }
         if (v != null) {
@@ -97,14 +92,16 @@ public class JaxbNonnullPlugin extends Plugin {
         v = getParameterValue(arg1, PARAM_NONNULL_CLASS);
         if (v != null)
             consumed++;
-        else {
+        else if (nonnullClass == null) {
             v = NOTNULL_ANNOTATION;
         }
-        try {
-            nonnullClass = (Class<? extends Annotation>) Class.forName(v);
-        } catch (Throwable e) {
-            log(e);
-            throw new BadCommandLineException("Invalid '" + PARAM_NONNULL_CLASS + "' value ('" + v + "') - must be Annotation class. Error: " + e.getMessage());
+        if (v != null) {
+            try {
+                nonnullClass = (Class<? extends Annotation>) Class.forName(v);
+            } catch (Throwable e) {
+                log(e);
+                throw new BadCommandLineException("Invalid '" + PARAM_NONNULL_CLASS + "' value ('" + v + "') - must be Annotation class. Error: " + e.getMessage());
+            }
         }
 
         // verbose
@@ -188,13 +185,13 @@ public class JaxbNonnullPlugin extends Plugin {
         boolean required = property.isRequired();
         if ((minOccurs < 0 || minOccurs >= 1 && required && !nillable)
                 || property.isCollection()
-                ) {
+        ) {
             processNonnull(classOutline, field);
         }
     }
 
     private void processListItemNonnull(Outline model, ClassOutline co, JFieldVar field) {
-        JClass origTp = (JClass)field.type();
+        JClass origTp = (JClass) field.type();
         JClass listClass = origTp.getBaseClass(List.class).erasure();
         JClass tp = listClass.narrow(new NonnullGenericClass(model, origTp.getTypeParameters().get(0), nonnullClass.getSimpleName()));
         log("Add @" + nonnullClass.getSimpleName() + " on list " + field.name() + " item of class " + co.implClass.name());
@@ -285,7 +282,7 @@ public class JaxbNonnullPlugin extends Plugin {
 
     private void log(String log) {
         if (verbose) {
-            System.out.println("JaxbJsr305: "+ log);
+            System.out.println("JaxbJsr305: " + log);
         }
     }
 
@@ -297,19 +294,52 @@ public class JaxbNonnullPlugin extends Plugin {
     static class NonnullGenericClass extends JClass {
         private final JClass origTp;
         private final String nonnullName;
+
         public NonnullGenericClass(Outline model, JClass origTp, String nonnullName) {
             super(model.getCodeModel());
             this.origTp = origTp;
             this.nonnullName = nonnullName;
         }
-        @Override public String fullName() { return formatGenericNonnull(nonnullName, origTp.fullName()); }
-        @Override public String name() { return formatGenericNonnull(nonnullName, origTp.name()); }
-        @Override public JPackage _package() { return origTp._package(); }
-        @Override public JClass _extends() { return origTp._extends(); }
-        @Override public Iterator<JClass> _implements() { return origTp._implements(); }
-        @Override public boolean isInterface() { return origTp.isInterface(); }
-        @Override public boolean isAbstract() { return origTp.isAbstract(); }
-        @Override protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) { return this; }
+
+        @Override
+        public String fullName() {
+            return formatGenericNonnull(nonnullName, origTp.fullName());
+        }
+
+        @Override
+        public String name() {
+            return formatGenericNonnull(nonnullName, origTp.name());
+        }
+
+        @Override
+        public JPackage _package() {
+            return origTp._package();
+        }
+
+        @Override
+        public JClass _extends() {
+            return origTp._extends();
+        }
+
+        @Override
+        public Iterator<JClass> _implements() {
+            return origTp._implements();
+        }
+
+        @Override
+        public boolean isInterface() {
+            return origTp.isInterface();
+        }
+
+        @Override
+        public boolean isAbstract() {
+            return origTp.isAbstract();
+        }
+
+        @Override
+        protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
+            return this;
+        }
 
         // format nonnull annotation with className (bit weird syntax)
         private String formatGenericNonnull(String nonnullName, String className) {


### PR DESCRIPTION
👋 

To plan the migration from `javax` to `jakarta`, we switch to your plugin to support the jsr305 to enhance our XML model that is used in our Kotlin codebase. 

By switching to your plugin, we noticed few bugs: 
- if multiple parameters are used with XJC, for each parameters, the plugin options are reseted to the default then the last parameter is applied. That way, if you have two parameters, the first one is always ignored. (at least with `defaultNullableClass` and `nonnullClass`) 
- The fix is to set the default value only if no value was assigned before.
- The second issue if about the getter detection. By not detecting the getter correctly, the annotation `@NotNull` was not set on the getter (while it should). 
- It happens when the getter doesn't match the field name. ie: if a field is named `_static`, the associated getter is `getStatic`. The underscore is added to the field as `static` is a reserved keyword but is a valid field name in XML.
- The strategy here is to check if a method contains the code `return <field name>;`. If so, it has to be the getter. ie: `return _static;` in my example.

Regards